### PR TITLE
fix for mac + add GITHUB_TOKEN

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -25,13 +25,13 @@ jobs:
           path: ~/.dove
           key: ${{ runner.os }}-dove
       - name: download latest version
-        uses: pontem-network/get-dove@fix
+        uses: pontem-network/get-dove@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: test
         run: dove -V
       - name: download 1.2.1 version
-        uses: pontem-network/get-dove@fix
+        uses: pontem-network/get-dove@main
         with:
           version: 1.2.1
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         shell: bash
     steps:
       - name: download 1.1.4 version
-        uses: pontem-network/get-dove@fix
+        uses: pontem-network/get-dove@main
         with:
           version: 1.1.4
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -25,12 +25,25 @@ jobs:
           path: ~/.dove
           key: ${{ runner.os }}-dove
       - name: download latest version
-        uses: pontem-network/get-dove@main
+        uses: pontem-network/get-dove@fix
       - name: test
         run: dove -V
       - name: download 1.2.1 version
-        uses: pontem-network/get-dove@main
+        uses: pontem-network/get-dove@fix
         with:
           version: 1.2.1
+      - name: test
+        run: dove -V
+
+  macos_test_for_1_1_4:
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: download 1.1.4 version
+        uses: pontem-network/get-dove@fix
+        with:
+          version: 1.1.4
       - name: test
         run: dove -V

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -19,6 +19,11 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.dove
+          key: ${{ runner.os }}-dove
       - name: download latest version
         uses: pontem-network/get-dove@fix
         with:

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -19,19 +19,17 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.dove
-          key: ${{ runner.os }}-dove
       - name: download latest version
         uses: pontem-network/get-dove@fix
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: test
         run: dove -V
       - name: download 1.2.1 version
         uses: pontem-network/get-dove@fix
         with:
           version: 1.2.1
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: test
         run: dove -V
 
@@ -45,5 +43,6 @@ jobs:
         uses: pontem-network/get-dove@fix
         with:
           version: 1.1.4
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: test
         run: dove -V

--- a/.github/workflows/test_bashfile.yml
+++ b/.github/workflows/test_bashfile.yml
@@ -19,6 +19,11 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.dove
+          key: ${{ runner.os }}-dove
       - name: Checkout
         uses: actions/checkout@v1
       - name: access

--- a/.github/workflows/test_bashfile.yml
+++ b/.github/workflows/test_bashfile.yml
@@ -19,11 +19,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
     steps:
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.dove
-          key: ${{ runner.os }}-dove
       - name: Checkout
         uses: actions/checkout@v1
       - name: access

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This GitHub Action delivers specified [`dove`] release for a Move language.
 ## Parameters
 
 - `version` - specified version of the release. Optional. Default value is `latest`.
+- `token` - GITHUB_TOKEN. Optional.
 
 
 ## Usage Example
@@ -26,4 +27,14 @@ Download a specific version of dove
   uses: pontem-network/get-dove@main
   with:
     version: 1.2.2
+```
+
+Download a specific version of dove and token
+
+```yaml
+- name: get dove
+  uses: pontem-network/get-dove@main
+  with:
+    version: 1.2.0
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,6 @@ inputs:
     default: "latest"
   token:
     description: "GITHUB_TOKEN"
-    required: true
-    default: ""
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Dove version (ex. `1.2.2` or default `latest`).
     required: true
     default: "latest"
+  token:
+    description: "GITHUB_TOKEN"
+    required: true
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -19,6 +23,6 @@ runs:
         fi
       shell: bash
     - name: Download
-      run: $GITHUB_ACTION_PATH/dove_download.sh ${{inputs.version}}
+      run: $GITHUB_ACTION_PATH/dove_download.sh ${{inputs.version}} ${{inputs.token}}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: "latest"
   token:
-    description: "GITHUB_TOKEN"
+    description: "GITHUB_TOKEN. Optional"
 runs:
   using: "composite"
   steps:

--- a/dove_download.sh
+++ b/dove_download.sh
@@ -11,13 +11,14 @@ releases_path="$basefolder/releases.json"
 if [ ! -e $releases_path ] || [ $(($(date "+%s")-$(date -r $releases_path "+%s" ))) -ge 600 ]; then
   echo "Download: releases.json"
   if [ -z $2 ]; then
-    curl -o "$releases_path" \
+    curl -o "$releases_path.tmp" \
         -s https://api.github.com/repos/pontem-network/move-tools/releases
   else
-    curl -o "$releases_path" \
+    curl -o "$releases_path.tmp" \
         -H "Authorization: Bearer ${2}" \
         -s https://api.github.com/repos/pontem-network/move-tools/releases
   fi
+  mv "$releases_path.tmp" $releases_path
 fi
 
 dove_version=""
@@ -63,15 +64,16 @@ if [ ! -e $file_path ]; then
   if [ -z $2 ]; then
     curl -sL --fail \
       -H "Accept: application/octet-stream" \
-      -o $file_path \
+      -o "$file_path.tmp" \
       -s $download_url
   else
     curl -sL --fail \
       -H "Accept: application/octet-stream" \
       -H "Authorization: Bearer ${2}" \
-      -o $file_path \
+      -o "$file_path.tmp" \
       -s $download_url
   fi
+  mv "$file_path.tmp" $file_path
 fi
 
 echo "chmod 1755 $file_path"

--- a/dove_download.sh
+++ b/dove_download.sh
@@ -8,7 +8,8 @@ if [ ! -e $basefolder ]; then
 fi
 releases_path="$basefolder/releases.json"
 
-if [ ! -e $releases_path ] || [ $(expr $(stat -c %Y "$releases_path") + 600) -le $(date +%s) ]; then
+differencetime=$(($(date "+%s")-$(date -r $releases_path "+%s" )))
+if [ ! -e $releases_path ] || [ $differencetime -ge 600 ]; then
   echo "Download: releases.json"
   curl -o "$releases_path" \
       -s https://api.github.com/repos/pontem-network/move-tools/releases
@@ -18,8 +19,7 @@ dove_version=""
 if [[ $1 == "latest" || $1 == "new" || $1 == "last" || -z $1 ]]; then
   dove_version=$(cat "$releases_path" | jq -r '.[0] .tag_name')
 else
-  if [ ! $(cat "$releases_path" |
-    jq ".[] | select(.tag_name==\"${1}\") .tag_name") ]; then
+  if [ ! $(cat "$releases_path" | jq ".[] | select(.tag_name==\"${1}\") .tag_name") ]; then
     echo "{$1} The specified version of dove was not found"
     exit 1
   fi
@@ -43,8 +43,14 @@ file_path="$basefolder/$filename"
 download_url=$(cat "$releases_path" |
   jq -r ".[] | select(.tag_name==\"${dove_version}\") .assets | .[] | select(.name|test(\"^dove-${dove_version}-${download_type}\")) | .browser_download_url")
 if [ -z $download_url ]; then
-  echo "Releases \"dove-${dove_version}-${download_type}\" not found"
-  exit 3
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+      download_url=$(cat "$releases_path" |
+        jq -r ".[] | select(.tag_name==\"${dove_version}\") .assets | .[] | select(.name|test(\"^dove-${dove_version}-mac-${HOSTTYPE}\")) | .browser_download_url")
+  fi
+  if [ -z $download_url ]; then
+    echo "Releases \"dove-${dove_version}-${download_type}\" not found"
+    exit 3
+  fi
 fi
 
 if [ ! -e $file_path ]; then

--- a/dove_download.sh
+++ b/dove_download.sh
@@ -8,11 +8,16 @@ if [ ! -e $basefolder ]; then
 fi
 releases_path="$basefolder/releases.json"
 
-differencetime=$(($(date "+%s")-$(date -r $releases_path "+%s" )))
-if [ ! -e $releases_path ] || [ $differencetime -ge 600 ]; then
+if [ ! -e $releases_path ] || [ $(($(date "+%s")-$(date -r $releases_path "+%s" ))) -ge 600 ]; then
   echo "Download: releases.json"
-  curl -o "$releases_path" \
-      -s https://api.github.com/repos/pontem-network/move-tools/releases
+  if [ -z $2 ]; then
+    curl -o "$releases_path" \
+        -s https://api.github.com/repos/pontem-network/move-tools/releases
+  else
+    curl -o "$releases_path" \
+        -H "Authorization: Bearer ${2}" \
+        -s https://api.github.com/repos/pontem-network/move-tools/releases
+  fi
 fi
 
 dove_version=""
@@ -55,10 +60,18 @@ fi
 
 if [ ! -e $file_path ]; then
   echo "Download: $download_url"
-  curl -sL --fail \
-    -H "Accept: application/octet-stream" \
-    -o $file_path \
-    -s $download_url
+  if [ -z $2 ]; then
+    curl -sL --fail \
+      -H "Accept: application/octet-stream" \
+      -o $file_path \
+      -s $download_url
+  else
+    curl -sL --fail \
+      -H "Accept: application/octet-stream" \
+      -H "Authorization: Bearer ${2}" \
+      -o $file_path \
+      -s $download_url
+  fi
 fi
 
 echo "chmod 1755 $file_path"


### PR DESCRIPTION
> stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
expr: syntax error
/Users/runner/work/_actions/pontem-network/get-dove/main/dove_download.sh: line 11: [: -le: unary operator expected

And 

An alternative name " mac " has been added for Mac OS. Previously, the 1.1.4 version could not be downloaded because of this.