### PR TITLE
rename dove repo

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -17,7 +17,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # TODO: return windows back when it supported
+          # - windows-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache

--- a/.github/workflows/test_bashfile.yml
+++ b/.github/workflows/test_bashfile.yml
@@ -17,7 +17,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # TODO: return windows back when it supported
+          # - windows-latest
     steps:
       - name: Cache
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This GitHub Action delivers specified [`dove`] release for a Move language.
 
-[`dove`]: https://github.com/pontem-network/move-tools
+[`dove`]: https://github.com/pontem-network/dove
 
 
 ## Parameters

--- a/dove_download.sh
+++ b/dove_download.sh
@@ -30,11 +30,11 @@ if [ ! -e $releases_path ] || [ $(($(date "+%s")-$(date -r $releases_path "+%s" 
   echo "Download: releases.json";
   if [ -z $SECRET_TOKEN ]; then
     curl -o "$releases_path.tmp" \
-        -s https://api.github.com/repos/pontem-network/move-tools/releases;
+        -s https://api.github.com/repos/pontem-network/dove/releases;
   else
     curl -o "$releases_path.tmp" \
         -H "Authorization: Bearer ${SECRET_TOKEN}" \
-        -s https://api.github.com/repos/pontem-network/move-tools/releases;
+        -s https://api.github.com/repos/pontem-network/dove/releases;
   fi;
   mv "$releases_path.tmp" $releases_path;
 fi;


### PR DESCRIPTION
Temporarily removed releases for windows from tests. It still available to get with `get-dove` if release available in the __dove__ repo.